### PR TITLE
Update to the module to work with platform 2.0.x

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -12,6 +12,7 @@
 	<packaging>jar</packaging>
 	<name>Haiti Core API</name>
 	<description>API project for Haiti Core</description>
+
 	<build>
 		<resources>
 			<resource>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -12,7 +12,6 @@
 	<packaging>jar</packaging>
 	<name>Haiti Core API</name>
 	<description>API project for Haiti Core</description>
-
 	<build>
 		<resources>
 			<resource>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
 	<properties>
 		<openMRSVersion>1.10.4</openMRSVersion>
-		<metadatadeployVersion>1.7</metadatadeployVersion>
+		<metadatadeployVersion>1.8.1</metadatadeployVersion>
 		<emrapiVersion>1.21.0</emrapiVersion>
 		<reportingVersion>0.11.0</reportingVersion>
 		<calculationVersion>1.2</calculationVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,13 @@
 			<version>${emrapiVersion}</version>
 			<scope>provided</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>emrapi-api-1.12</artifactId>
+			<version>${emrapiVersion}</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- OpenMRS modules required just to fire up application context during testing -->
 
@@ -135,6 +142,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>serialization.xstream-api-2.0</artifactId>
+			<version>${serializationxstreamVersion}</version>
+			<scope>test</scope>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>metadatamapping-api</artifactId>


### PR DESCRIPTION
I added the appropriate dependencies for Platform 2.0.x:
emrapi-api-1.12
serialization.xstream-api-2.0

I also updated the dependency on metadatadeploy from v 1.7 to 1.8.1 due to a fix in the hibernate session. The module builds correctly now on platform 2.0.x