### PR TITLE
Adding Biometric patient identifier type

### DIFF
--- a/api/src/main/java/org/openmrs/module/haiticore/HaitiCoreInstaller.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/HaitiCoreInstaller.java
@@ -4,6 +4,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.haiticore.metadata.HaitiAddressBundle;
 import org.openmrs.module.haiticore.metadata.HaitiEncounterTypeBundle;
 import org.openmrs.module.haiticore.metadata.HaitiPersonAttributeTypeBundle;
+import org.openmrs.module.haiticore.metadata.HaitiPatientIdentifierTypeBundle;
 import org.openmrs.module.metadatadeploy.api.MetadataDeployService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ public class HaitiCoreInstaller {
         metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiPersonAttributeTypeBundle.class).get(0));
         metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiEncounterTypeBundle.class).get(0));
         metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiAddressBundle.class).get(0));
+        metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiPatientIdentifierTypeBundle.class).get(0));
     }
 
 }

--- a/api/src/main/java/org/openmrs/module/haiticore/metadata/AddressBundle.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/metadata/AddressBundle.java
@@ -73,6 +73,10 @@ public abstract class AddressBundle extends VersionedMetadataBundle {
     /**
      * @return a new AddressTemplate instance for the given configuration
      */
+    /* This Object utilizes the reflection method to identify the correct constructing class because the API
+     * for address template changed from "org.openmrs.layout.web.address.AddressTemplate" prior to OpenMRS platform v1.12
+     * and "org.openmrs.layout.address.AddressTemplate" thereafter.
+     */
     public Object getAddressTemplate() {
     	Object addressTemplate = null;
         try {

--- a/api/src/main/java/org/openmrs/module/haiticore/metadata/HaitiPatientIdentifierTypeBundle.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/metadata/HaitiPatientIdentifierTypeBundle.java
@@ -1,0 +1,18 @@
+package org.openmrs.module.haiticore.metadata;
+
+import org.openmrs.module.metadatadeploy.bundle.AbstractMetadataBundle;
+import org.openmrs.module.haiticore.metadata.HaitiPatientIdentifierTypes;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HaitiPatientIdentifierTypeBundle extends AbstractMetadataBundle {
+
+    @Override
+    public void install() throws Exception {
+
+        log.info("Installing PatientIdentifierTypes");
+
+        install(HaitiPatientIdentifierTypes.BIOMETRIC_REF_NUMBER);
+    }
+
+}

--- a/api/src/main/java/org/openmrs/module/haiticore/metadata/HaitiPatientIdentifierTypes.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/metadata/HaitiPatientIdentifierTypes.java
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+
+package org.openmrs.module.haiticore.metadata;
+
+import org.openmrs.module.metadatadeploy.descriptor.PatientIdentifierTypeDescriptor;
+
+/**
+ * Constants for all defined patient identifier types
+ */
+public class HaitiPatientIdentifierTypes {
+
+	public static PatientIdentifierTypeDescriptor BIOMETRIC_REF_NUMBER = new PatientIdentifierTypeDescriptor() {
+		public String uuid() { return "e26ca279-8f57-44a5-9ed8-8cc16e90e559"; }
+		public String name() { return "Biometrics Reference Code"; }
+		public String description() { return "Code referencing a patient's record in an external biometrics system"; }
+	};
+
+}


### PR DESCRIPTION
We are adding this to haiticore so our teams can begin to develop the M2Sys fingerprint server integration that will be delivered in iSantéPlus this fall.