### PR TITLE
Splitting Patient Identifier into multiple bundles

### DIFF
--- a/api/src/main/java/org/openmrs/module/haiticore/HaitiCoreInstaller.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/HaitiCoreInstaller.java
@@ -4,7 +4,8 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.haiticore.metadata.HaitiAddressBundle;
 import org.openmrs.module.haiticore.metadata.HaitiEncounterTypeBundle;
 import org.openmrs.module.haiticore.metadata.HaitiPersonAttributeTypeBundle;
-import org.openmrs.module.haiticore.metadata.HaitiPatientIdentifierTypeBundle;
+import org.openmrs.module.haiticore.metadata.patientidentifiertypebundles.HaitiBiometricPatientIdentifierTypeBundle;
+import org.openmrs.module.haiticore.metadata.patientidentifiertypebundles.HaitiSedishMpiPatientIdentifierTypeBundle;
 import org.openmrs.module.metadatadeploy.api.MetadataDeployService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -19,7 +20,8 @@ public class HaitiCoreInstaller {
         metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiPersonAttributeTypeBundle.class).get(0));
         metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiEncounterTypeBundle.class).get(0));
         metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiAddressBundle.class).get(0));
-        metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiPatientIdentifierTypeBundle.class).get(0));
+        metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiBiometricPatientIdentifierTypeBundle.class).get(0));
+        metadataDeployService.installBundle(Context.getRegisteredComponents(HaitiSedishMpiPatientIdentifierTypeBundle.class).get(0));
     }
 
 }

--- a/api/src/main/java/org/openmrs/module/haiticore/metadata/HaitiPatientIdentifierTypeBundle.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/metadata/HaitiPatientIdentifierTypeBundle.java
@@ -13,6 +13,7 @@ public class HaitiPatientIdentifierTypeBundle extends AbstractMetadataBundle {
         log.info("Installing PatientIdentifierTypes");
 
         install(HaitiPatientIdentifierTypes.BIOMETRIC_REF_NUMBER);
+        install(HaitiPatientIdentifierTypes.SEDISH_MPI_ECID);
     }
 
 }

--- a/api/src/main/java/org/openmrs/module/haiticore/metadata/HaitiPatientIdentifierTypes.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/metadata/HaitiPatientIdentifierTypes.java
@@ -27,4 +27,10 @@ public class HaitiPatientIdentifierTypes {
 		public String description() { return "Code referencing a patient's record in an external biometrics system"; }
 	};
 
+	public static PatientIdentifierTypeDescriptor SEDISH_MPI_ECID = new PatientIdentifierTypeDescriptor() {
+		public String uuid() { return "f54ed6b9-f5b9-4fd5-a588-8f7561a78401"; }
+		public String name() { return "ECID"; }
+		public String description() { return "Code referencing a patient's record in the SEDISH Master Person Index (Enterprise Client ID)"; }
+	};
+
 }

--- a/api/src/main/java/org/openmrs/module/haiticore/metadata/patientidentifiertypebundles/HaitiBiometricPatientIdentifierTypeBundle.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/metadata/patientidentifiertypebundles/HaitiBiometricPatientIdentifierTypeBundle.java
@@ -1,19 +1,18 @@
-package org.openmrs.module.haiticore.metadata;
+package org.openmrs.module.haiticore.metadata.patientidentifiertypebundles;
 
 import org.openmrs.module.metadatadeploy.bundle.AbstractMetadataBundle;
 import org.openmrs.module.haiticore.metadata.HaitiPatientIdentifierTypes;
 import org.springframework.stereotype.Component;
 
 @Component
-public class HaitiPatientIdentifierTypeBundle extends AbstractMetadataBundle {
+public class HaitiBiometricPatientIdentifierTypeBundle extends AbstractMetadataBundle {
 
     @Override
     public void install() throws Exception {
 
-        log.info("Installing PatientIdentifierTypes");
+        log.info("Installing Biometric PatientIdentifierType");
 
         install(HaitiPatientIdentifierTypes.BIOMETRIC_REF_NUMBER);
-        install(HaitiPatientIdentifierTypes.SEDISH_MPI_ECID);
     }
 
 }

--- a/api/src/main/java/org/openmrs/module/haiticore/metadata/patientidentifiertypebundles/HaitiSedishMpiPatientIdentifierTypeBundle.java
+++ b/api/src/main/java/org/openmrs/module/haiticore/metadata/patientidentifiertypebundles/HaitiSedishMpiPatientIdentifierTypeBundle.java
@@ -1,0 +1,18 @@
+package org.openmrs.module.haiticore.metadata.patientidentifiertypebundles;
+
+import org.openmrs.module.metadatadeploy.bundle.AbstractMetadataBundle;
+import org.openmrs.module.haiticore.metadata.HaitiPatientIdentifierTypes;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HaitiSedishMpiPatientIdentifierTypeBundle extends AbstractMetadataBundle {
+
+    @Override
+    public void install() throws Exception {
+
+        log.info("Installing SEDISH MPI PatientIdentifierType");
+
+        install(HaitiPatientIdentifierTypes.SEDISH_MPI_ECID);
+    }
+
+}

--- a/api/src/test/java/org/openmrs/module/haiticore/HaitiCoreActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/haiticore/HaitiCoreActivatorTest.java
@@ -3,6 +3,7 @@ package org.openmrs.module.haiticore;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.api.PersonService;
+import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.addresshierarchy.AddressField;
 import org.openmrs.module.addresshierarchy.AddressHierarchyLevel;
@@ -10,6 +11,8 @@ import org.openmrs.module.addresshierarchy.service.AddressHierarchyService;
 import org.openmrs.module.haiticore.metadata.HaitiAddressBundle;
 import org.openmrs.module.haiticore.metadata.HaitiPersonAttributeTypeBundle;
 import org.openmrs.module.haiticore.metadata.HaitiPersonAttributeTypes;
+import org.openmrs.module.haiticore.metadata.HaitiPatientIdentifierTypes;
+
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -27,13 +30,16 @@ public class HaitiCoreActivatorTest extends BaseModuleContextSensitiveTest {
 
     @Autowired
     private PersonService personService;
+    
+    @Autowired
+    private PatientService patientService;
 
     @Autowired
     private HaitiPersonAttributeTypeBundle personAttributeTypeBundle;
 
     @Autowired
     private HaitiAddressBundle addressBundle;
-
+    
     @Test
     public void testMetadataBundles() throws Exception {
 
@@ -43,6 +49,9 @@ public class HaitiCoreActivatorTest extends BaseModuleContextSensitiveTest {
         assertThat(personService.getAllPersonAttributeTypes().size(), is(7)); // the 4 that the bundle installs + the 3 from standard test dataset
         assertNotNull(personService.getPersonAttributeTypeByUuid(HaitiPersonAttributeTypes.MOTHERS_FIRST_NAME.uuid()));
     
+        // test the patient identifier type is loaded
+        assertNotNull(patientService.getPatientIdentifierTypeByUuid(HaitiPatientIdentifierTypes.BIOMETRIC_REF_NUMBER.uuid()));
+        
         // test the address hierarchy
         verifyAddressHierarchyLevelsCreated();
         verifyAddressHierarchyLoaded();


### PR DESCRIPTION
FYI: @mogoodrich,

As we discussed, I split the patient identifiers into different bundles so they could be loaded independently. This will require that you update pihcore because the name changed to BiometricPatientIdentifierTypeBundle.

Please squash the commits when you merge with master.