### PR TITLE
RA-2020:Fixed auto update of translations from transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,9 @@
 [main]
 host = https://www.transifex.com/
 
-[OpenMRS.haiti-core-module]
+[o:openmrs:p:OpenMRS:r:haiti-core-module]
+file_filter = api/src/main/resources/messages_<lang>.properties
 source_file = api/src/main/resources/messages.properties
 source_lang = en
-file_filter = api/src/main/resources/messages_<lang>.properties
-type = UNICODEPROPERTIES 
+type        = UNICODEPROPERTIES
+

--- a/.tx/config
+++ b/.tx/config
@@ -4,24 +4,5 @@ host = https://www.transifex.com/
 [OpenMRS.haiti-core-module]
 source_file = api/src/main/resources/messages.properties
 source_lang = en
-type = UNICODEPROPERTIES
-trans.ar = api/src/main/resources/messages_ar.properties
-trans.de = api/src/main/resources/messages_de.properties
-trans.el = api/src/main/resources/messages_el.properties
-trans.es = api/src/main/resources/messages_es.properties
-trans.fa = api/src/main/resources/messages_fa.properties
-trans.fr = api/src/main/resources/messages_fr.properties
-trans.hi = api/src/main/resources/messages_hi.properties
-trans.ht = api/src/main/resources/messages_ht.properties
-trans.hy = api/src/main/resources/messages_hy.properties
-trans.id_ID = api/src/main/resources/messages_id_ID.properties
-trans.it = api/src/main/resources/messages_it.properties
-trans.ku = api/src/main/resources/messages_ku.properties
-trans.lt = api/src/main/resources/messages_lt.properties
-trans.pl = api/src/main/resources/messages_pl.properties
-trans.pt = api/src/main/resources/messages_pt.properties
-trans.ru = api/src/main/resources/messages_ru.properties
-trans.si = api/src/main/resources/messages_si.properties
-trans.sw = api/src/main/resources/messages_sw.properties
-trans.te = api/src/main/resources/messages_te.properties
-
+file_filter = api/src/main/resources/messages_<lang>.properties
+type = UNICODEPROPERTIES 


### PR DESCRIPTION
**Description of what I changed**
Updated my transifex client.
Running tx migrate created a back up for previous config.
Runningtx pull --all -f I was able to pull down all message property translation files and have them update the source on my machine. The -f flag ensured that my machine was updated from the server, even if the files were newer. I then committed these changes back to the repo.

**Issue I worked on**
https://issues.openmrs.org/browse/RA-2020